### PR TITLE
typo: space between hashes and text

### DIFF
--- a/_posts/2015-04-19-in-praise-of-mpi-collectives-and-mpi-io.md
+++ b/_posts/2015-04-19-in-praise-of-mpi-collectives-and-mpi-io.md
@@ -71,7 +71,7 @@ Calls to MPI collective operations or MPI-IO describe what should be done, not h
 
 Operations like "All processes sum their results and distribute the result to all processes", or "Each process writes to their slice of the file" are enormously broader than "Send this message to process X".  There's a large number of ways they could be implemented, and in fact there's a huge literature on both [collectives](https://scholar.google.ca/scholar?q=mpi+collectives) and [MPI-IO](https://scholar.google.ca/scholar?q=mpi-io) on various approaches to doing so.
 
-###Application programmers reimplementing them would be worse for performance
+### Application programmers reimplementing them would be worse for performance
 
 If the "low-level application programming is essential for high performance" argument was true, then of course we would be actively dissuading researchers from using these high-level tools.  But we don't, and we're right not to.  
 
@@ -83,7 +83,7 @@ MPI collective operation implementations make run-time decisions behind the rese
 
 Somebody had to do all that challenging low-level work, yes.  But the idea that those optimizations and algorithmic work is properly the job of the researcher/application programmer is absurd.
 
-###Implementations got faster and faster
+### Implementations got faster and faster
 
 These highly optimized implementations of these high-level abstractions did not, of course, spring fully formed from nowhere, any more than the [reference implementation of LAPACK/BLAS](http://www.netlib.org/lapack/) was blazingly fast.  The abstractions were created with an understanding of both what application programmers needed and what was implementable, and then years and years of work went into developing the algorithms and implementations that we make use of today.
 


### PR DESCRIPTION
This makes the markdown render as intended.